### PR TITLE
Thomas/fix/added n to within

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Parameters:
 - `perform` the action you want to perform to fetch your data, your options are:
   - `right_of` fetch the value to the right of the cell labeled in `find`
   - `below_of` fetch the value to beneath of the cell labeled in `find`
+- `n` pick the value n values away in the specified perform direction (right_of or below_of)
 
 ### `search_below_of`
 Searches for non-empty cell below of the cell with the given label.

--- a/src/exco/extractor/locator/built_in/within_locator.py
+++ b/src/exco/extractor/locator/built_in/within_locator.py
@@ -15,6 +15,7 @@ class WithinLocator(Locator):
     find: str
     direction: str
     perform: str
+    n: int = 1
 
     valid_directions = ["right_of", "below_of"]
 
@@ -51,11 +52,11 @@ class WithinLocator(Locator):
             coord = util.get_rightmost_coordinate(sheet=sheet, cell=cell)
             return CellLocation(
                 sheet_name=sheet.title,
-                coordinate=util.shift_coord(coord.coordinate, (0, 1))
+                coordinate=util.shift_coord(coord.coordinate, (0, self.n))
             )
         if self.perform == "below_of":
             coord = util.get_bottommost_coordinate(sheet=sheet, cell=cell)
             return CellLocation(
                 sheet_name=sheet.title,
-                coordinate=util.shift_coord(coord.coordinate, (1, 0))
+                coordinate=util.shift_coord(coord.coordinate, (self.n, 0))
             )

--- a/tests/extractor/test_within_locator.py
+++ b/tests/extractor/test_within_locator.py
@@ -81,6 +81,12 @@ def wb() -> CellFullPath:
     ws['H22'] = 2
     ws['G23'] = 1
 
+    # 5 to the right of repeated_cell_name
+    ws['L22'] = 5
+
+    # 6 to the below of repeated_cell_name
+    ws['G27'] = 6
+
     ws['D36'] = below_of_name
     ws['D37'] = 8
     ws['E36'] = 9
@@ -102,6 +108,34 @@ def wb() -> CellFullPath:
     ws['E60'] = 15
 
     return wb
+
+
+def test_within_locator_n_right_of(wb: Workbook):
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=repeated_cell_name,
+                        perform=right_of_direction, n=5)
+    result = rol.locate(anchor_cell_location=CellLocation(
+        sheet_name="Sheet",
+        coordinate="C1"
+    ), workbook=wb)
+    cell_loc = CellLocation(
+        sheet_name="Sheet",
+        coordinate="L22"
+    )
+    assert result == LocatingResult.good(cell_loc)
+
+
+def test_within_locator_n_below_of(wb: Workbook):
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=repeated_cell_name,
+                        perform=below_of_direction, n=5)
+    result = rol.locate(anchor_cell_location=CellLocation(
+        sheet_name="Sheet",
+        coordinate="C1"
+    ), workbook=wb)
+    cell_loc = CellLocation(
+        sheet_name="Sheet",
+        coordinate="G27"
+    )
+    assert result == LocatingResult.good(cell_loc)
 
 
 def test_within_locator_no_such_label_on_table_fail(wb: Workbook):

--- a/tests/extractor/test_within_locator.py
+++ b/tests/extractor/test_within_locator.py
@@ -19,6 +19,19 @@ non_existent_cell = 'non existent'
 right_of_name = 'right of'
 cell_above_everything = 'top hidden cell'
 
+# directions
+right_of_direction = "right_of"
+below_of_direction = 'below_of'
+
+
+def _create_error_message(table_name: str = None,
+                          cell_name: str = None,
+                          direction: str = None,
+                          label: str = None) -> str:
+    if label is not None:
+        return "Unable to find cell with label " + label
+    return "Unable to find cell " + cell_name + " to the " + direction.replace('_', ' ') + " " + table_name
+
 
 @pytest.fixture
 def wb() -> CellFullPath:
@@ -92,36 +105,39 @@ def wb() -> CellFullPath:
 
 
 def test_within_locator_no_such_label_on_table_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label='fake table', find=repeated_cell_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label='fake table', find=repeated_cell_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell with label fake table")
+    assert result == LocatingResult.bad(msg=_create_error_message(label='fake table'))
 
 
 def test_within_locator_no_such_perform_on_table_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=repeated_cell_name, perform='top_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=repeated_cell_name, perform='top_of')
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Incorrect perform, must be one of the following ['right_of', 'below_of']")
+    assert result == LocatingResult.bad(msg=f"Incorrect perform, must be one of the following ['{right_of_direction}', "
+                                            f"'{below_of_direction}']")
 
 
 def test_within_locator_no_such_direction_fail(wb: Workbook):
-    rol = WithinLocator(direction='top_of', label=test_table_name, find=repeated_cell_name, perform='right_of')
+    rol = WithinLocator(direction='top_of', label=test_table_name, find=repeated_cell_name, perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
     ), workbook=wb)
     assert result == LocatingResult.bad(
-        msg="Incorrect direction, must be one of the following ['right_of', 'below_of']")
+        msg=f"Incorrect direction, must be one of the following ['{right_of_direction}', '{below_of_direction}']")
 
 
 # RIGHT OF
 def test_within_right_of(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=repeated_cell_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=repeated_cell_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
@@ -132,7 +148,8 @@ def test_within_right_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=repeated_cell_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=repeated_cell_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
@@ -145,7 +162,8 @@ def test_within_right_of(wb: Workbook):
 
 
 def test_within_right_of_single_cell(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=single_cell_name, find=right_of_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=single_cell_name, find=right_of_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -156,7 +174,8 @@ def test_within_right_of_single_cell(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=single_cell_name, find=right_of_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=single_cell_name, find=right_of_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -169,16 +188,20 @@ def test_within_right_of_single_cell(wb: Workbook):
 
 
 def test_within_right_of_single_cell_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=single_cell_name, find=non_existent_cell, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=single_cell_name, find=non_existent_cell,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + non_existent_cell + " to the right of single cell")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=single_cell_name,
+                                                                  cell_name=non_existent_cell,
+                                                                  direction=right_of_direction))
 
 
 def test_within_right_of_boundary_single_cell(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=single_cell_name, find=single_cell_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=single_cell_name, find=single_cell_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -189,7 +212,8 @@ def test_within_right_of_boundary_single_cell(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=single_cell_name, find=single_cell_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=single_cell_name, find=single_cell_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -202,55 +226,74 @@ def test_within_right_of_boundary_single_cell(wb: Workbook):
 
 
 def test_within_right_of_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=right_of_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=right_of_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A10"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + right_of_name + " to the right of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=right_of_name,
+                                                                  direction=right_of_direction))
 
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=right_of_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=right_of_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A10"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + right_of_name + " to the right of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=right_of_name,
+                                                                  direction=right_of_direction))
 
 
 def test_within_right_of_boundary_top_check_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_2_name, find=unable_to_find, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=unable_to_find,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A5"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the right of test table 2")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_2_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=right_of_direction))
 
-    rol = WithinLocator(direction='right_of', label=test_table_2_name, find=unable_to_find, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=unable_to_find,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A5"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the right of test table 2")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_2_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=right_of_direction))
 
 
 def test_within_right_of_boundary_below_check_fail(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=unable_to_find, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=unable_to_find,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A4"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the right of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=right_of_direction))
 
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=unable_to_find, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=unable_to_find,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A4"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the right of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=right_of_direction))
 
 
 def test_within_same_find_right_of(wb: Workbook):
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=repeated_cell_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=repeated_cell_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A6"
@@ -261,7 +304,8 @@ def test_within_same_find_right_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=test_table_2_name, find=repeated_cell_name, perform='right_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=repeated_cell_name,
+                        perform=right_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A7"
@@ -272,7 +316,8 @@ def test_within_same_find_right_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=test_table_name, find=repeated_cell_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_name, find=repeated_cell_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
@@ -283,7 +328,8 @@ def test_within_same_find_right_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='right_of', label=test_table_2_name, find=repeated_cell_name, perform='below_of')
+    rol = WithinLocator(direction=right_of_direction, label=test_table_2_name, find=repeated_cell_name,
+                        perform=below_of_direction)
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="A3"
@@ -297,23 +343,29 @@ def test_within_same_find_right_of(wb: Workbook):
 
 # below OF
 def test_within_below_of_single_cell_fail(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=non_existent_cell, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=non_existent_cell,
+                        perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + non_existent_cell + " to the below of single cell")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=single_cell_name,
+                                                                  cell_name=non_existent_cell,
+                                                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=non_existent_cell, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=non_existent_cell,
+                        perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + non_existent_cell + " to the below of single cell")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=single_cell_name,
+                                                                  cell_name=non_existent_cell,
+                                                                  direction=below_of_direction))
 
 
 def test_within_below_of_single_cell(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=below_of_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=below_of_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -324,7 +376,7 @@ def test_within_below_of_single_cell(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=below_of_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=below_of_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -337,7 +389,7 @@ def test_within_below_of_single_cell(wb: Workbook):
 
 
 def test_within_below_of_boundary_single_cell(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=single_cell_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=single_cell_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -348,7 +400,7 @@ def test_within_below_of_boundary_single_cell(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=single_cell_name, find=single_cell_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=single_cell_name, find=single_cell_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="Z1"
@@ -361,7 +413,7 @@ def test_within_below_of_boundary_single_cell(wb: Workbook):
 
 
 def test_within_below_of(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=below_of_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=below_of_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B3"
@@ -372,7 +424,7 @@ def test_within_below_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=below_of_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=below_of_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B3"
@@ -385,30 +437,36 @@ def test_within_below_of(wb: Workbook):
 
 
 def test_within_below_of_fail(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=right_of_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=right_of_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B10"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + right_of_name + " to the below of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=right_of_name,
+                                                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=right_of_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=right_of_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B10"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + right_of_name + " to the below of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=right_of_name,
+                                                                  direction=below_of_direction))
 
 
 def test_within_below_of_boundary_top_check_fail(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=test_table_2_name, find=unable_to_find, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_2_name, find=unable_to_find, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B5"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the below of test table 2")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_2_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=test_table_name,
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name,
                         find=cell_above_everything,
                         perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
@@ -416,16 +474,19 @@ def test_within_below_of_boundary_top_check_fail(wb: Workbook):
         coordinate="B5"
     ), workbook=wb)
     assert result == LocatingResult.bad(
-        msg="Unable to find cell " + cell_above_everything + " to the below of test table")
+        msg=_create_error_message(table_name=test_table_name, cell_name=cell_above_everything,
+                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=test_table_2_name, find=unable_to_find, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_2_name, find=unable_to_find, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B5"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the below of test table 2")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_2_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=test_table_name,
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name,
                         find=cell_above_everything,
                         perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
@@ -433,27 +494,32 @@ def test_within_below_of_boundary_top_check_fail(wb: Workbook):
         coordinate="B5"
     ), workbook=wb)
     assert result == LocatingResult.bad(
-        msg="Unable to find cell " + cell_above_everything + " to the below of test table")
+        msg=_create_error_message(table_name=test_table_name, cell_name=cell_above_everything,
+                                  direction=below_of_direction))
 
 
 def test_within_below_of_boundary_below_check_fail(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=unable_to_find, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=unable_to_find, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B4"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the below of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=below_of_direction))
 
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=unable_to_find, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=unable_to_find, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B4"
     ), workbook=wb)
-    assert result == LocatingResult.bad(msg="Unable to find cell " + unable_to_find + " to the below of test table")
+    assert result == LocatingResult.bad(msg=_create_error_message(table_name=test_table_name,
+                                                                  cell_name=unable_to_find,
+                                                                  direction=below_of_direction))
 
 
 def test_within_same_find_below_of(wb: Workbook):
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=below_of_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=below_of_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B6"
@@ -464,7 +530,7 @@ def test_within_same_find_below_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=test_table_3_name, find=below_of_name, perform="below_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_3_name, find=below_of_name, perform="below_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B7"
@@ -475,7 +541,7 @@ def test_within_same_find_below_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=test_table_name, find=below_of_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_name, find=below_of_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B6"
@@ -486,7 +552,7 @@ def test_within_same_find_below_of(wb: Workbook):
     )
     assert result == LocatingResult.good(cell_loc)
 
-    rol = WithinLocator(direction='below_of', label=test_table_3_name, find=below_of_name, perform="right_of")
+    rol = WithinLocator(direction=below_of_direction, label=test_table_3_name, find=below_of_name, perform="right_of")
     result = rol.locate(anchor_cell_location=CellLocation(
         sheet_name="Sheet",
         coordinate="B7"


### PR DESCRIPTION
While making the changes requested for format 2 I fell into issues similar to
![image](https://user-images.githubusercontent.com/65774362/187629779-2c1c6930-67a5-4d6f-aaef-fdf990a79650.png)
It turns out that within locator having an n spaces specifier is very useful.
Here is an example of how it is used.
![image](https://user-images.githubusercontent.com/65774362/187631969-748866b3-1fbb-403a-9192-d68be3b96dc1.png)
![image](https://user-images.githubusercontent.com/65774362/187632093-575c2cf3-fd57-4fdc-8e88-27dd6a42092d.png)
